### PR TITLE
Fix launching Steam from the desktop

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -188,6 +188,7 @@
                     "type": "shell",
                     "commands": [
                         "sed -i s:Icon=steam:Icon=com.valvesoftware.Steam: steam.desktop",
+                        "sed -i s:/usr/bin/steam:/app/bin/steam: steam.desktop",
                         "sed -i s:/usr/lib/:/app/lib/: steam"
                     ]
                 }


### PR DESCRIPTION
The desktop file was still referring the /usr/bin/steam executable
instead of /app/bin/steam.

https://phabricator.endlessm.com/T16470