### PR TITLE
Fix crash when Steam is configured to remember the password

### DIFF
--- a/com.valvesoftware.Steam.json
+++ b/com.valvesoftware.Steam.json
@@ -9,6 +9,7 @@
     "finish-args": [
         "--share=ipc", "--socket=x11",
         "--socket=pulseaudio",
+        "--socket=system-bus",
         "--share=network",
         "--talk-name=org.gnome.SettingsDaemon",
         "--device=all",


### PR DESCRIPTION
The problem was that under that configuration Steam tries to access the
system dbus, which was not accessible in the sandbox as we built the
app.
This patch grants permissions to the system dbus which fixes the issue.

https://phabricator.endlessm.com/T16584